### PR TITLE
Update ExifContainer.m

### DIFF
--- a/Classes/ExifContainer.m
+++ b/Classes/ExifContainer.m
@@ -107,7 +107,7 @@ NSString const * kCGImagePropertyProjection = @"ProjectionType";
 
 }
 
-- (void)setValue:(NSString *)key forExifKey:(NSString *)value {
+- (void)setValue:(NSString *)value forExifKey:(NSString *)key {
 
     [self.exifDictionary setObject:value forKey:key];
 


### PR DESCRIPTION
 Line 86 - 
[self setValue:comment forExifKey:key];

This passes value as "comment" and Exifkey as "Key"


It calls following function 

Line 110 -
- (void)setValue:(NSString *)key forExifKey:(NSString *)value {
    [self.exifDictionary setObject:value forKey:key];
}


- Issue : In line 86 we have value as first parameter and key as second parameter , this must be same in line 110 but it is "reversed" so corrected function

- (void)setValue:(NSString *)value forExifKey:(NSString *)key {
    [self.exifDictionary setObject:value forKey:key];
}